### PR TITLE
Add missing <key> tag for deep linking

### DIFF
--- a/ios.md
+++ b/ios.md
@@ -99,6 +99,7 @@ Setting up a Deep Link return, so that PayPal can let your app know, that paymen
 You can modify and paste the `XML` structure below into your `Info.plist`
 
 ```xml
+ <key>CFBundleURLTypes</key>
  <array>
 	<dict>
 		<key>CFBundleURLName</key>


### PR DESCRIPTION
<key>CFBundleURLTypes</key> was missing from instructions on how to create Deep Linking URL